### PR TITLE
feat(terraform): enable per-VM static IP and DHCP logic driven by variable input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,117 @@
+# vm_qemu_multiple
+
+OpenTofu/Terraform module for provisioning multiple QEMU VMs on Proxmox using the `telmate/proxmox` provider.
+
+Each VM in the `vms` list can independently use **DHCP** or a **static IP** — controlled entirely by the per-VM `ip` and `gw` fields.
+
+---
+
+## Usage
+
+### DHCP (default)
+
+Omit `ip` and `gw` (or explicitly set `ip = "dhcp"`). No gateway is required.
+
+```hcl
+module "vms" {
+  source = "github.com/Ngel-Castro/vm_qemu_multiple?ref=0.0.2"
+
+  proxmox_token_secret = var.proxmox_token_secret
+
+  vms = [
+    {
+      name           = "dns-server"
+      target_node    = "proxmox"
+      storage        = "local-lvm"
+      storage_size   = 32
+      full_clone     = true
+      template_name  = "ubuntu-server-beta"
+      network_bridge = "vmbr0"
+      memory         = 2048
+      cores          = 2
+      tags           = "tofu"
+      # ip and gw omitted → DHCP
+    }
+  ]
+}
+```
+
+### Static IP
+
+Provide both `ip` (CIDR notation) and `gw` (gateway). A `tofu plan` error is raised if `gw` is missing when a static IP is set.
+
+```hcl
+module "vms" {
+  source = "github.com/Ngel-Castro/vm_qemu_multiple?ref=0.0.2"
+
+  proxmox_token_secret = var.proxmox_token_secret
+
+  vms = [
+    {
+      name           = "web-server"
+      target_node    = "proxmox"
+      storage        = "local-lvm"
+      storage_size   = 32
+      full_clone     = true
+      template_name  = "ubuntu-server-beta"
+      network_bridge = "vmbr0"
+      memory         = 4096
+      cores          = 4
+      tags           = "tofu"
+      ip             = "192.168.3.10/24"
+      gw             = "192.168.3.1"
+    }
+  ]
+}
+```
+
+### Mixed — DHCP and static in the same list
+
+```hcl
+vms = [
+  {
+    name           = "vm-dhcp"
+    target_node    = "proxmox"
+    storage        = "local-lvm"
+    storage_size   = 32
+    full_clone     = true
+    template_name  = "ubuntu-server-beta"
+    network_bridge = "vmbr0"
+    memory         = 2048
+    cores          = 2
+    tags           = "tofu"
+    # DHCP — no ip/gw needed
+  },
+  {
+    name           = "vm-static"
+    target_node    = "proxmox"
+    storage        = "local-lvm"
+    storage_size   = 32
+    full_clone     = true
+    template_name  = "ubuntu-server-beta"
+    network_bridge = "vmbr0"
+    memory         = 2048
+    cores          = 2
+    tags           = "tofu"
+    ip             = "192.168.3.20/24"
+    gw             = "192.168.3.1"
+  }
+]
+```
+
+---
+
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_proxmox"></a> [proxmox](#requirement\_proxmox) | 3.0.2-rc07 |
+| [proxmox](https://registry.terraform.io/providers/telmate/proxmox/latest) | 3.0.2-rc07 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_proxmox"></a> [proxmox](#provider\_proxmox) | 3.0.2-rc07 |
-
-## Modules
-
-No modules.
+| proxmox | 3.0.2-rc07 |
 
 ## Resources
 
@@ -24,15 +123,34 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_environment"></a> [environment](#input\_environment) | on which enviroment the project will be running | `string` | `"dev"` | no |
-| <a name="input_proxmox_host"></a> [proxmox\_host](#input\_proxmox\_host) | Value for proxmox cluster/server | `string` | `"https://192.168.0.131:8006/api2/json"` | no |
-| <a name="input_proxmox_token_id"></a> [proxmox\_token\_id](#input\_proxmox\_token\_id) | Proxmox Token user@pam!token\_id | `string` | `"terraform-prov@pve!terraform"` | no |
-| <a name="input_proxmox_token_secret"></a> [proxmox\_token\_secret](#input\_proxmox\_token\_secret) | Proxmox token secret | `string` | n/a | yes |
-| <a name="input_vms"></a> [vms](#input\_vms) | List of VM definitions to create. `ip` defaults to `"dhcp"`. `vlan_tag` defaults to `3`. Omit `gw` when using DHCP. | <pre>list(object({<br>        name           = string<br>        target_node    = string<br>        storage        = string<br>        storage_size   = number<br>        full_clone     = bool<br>        template_name  = string<br>        network_bridge = string<br>        memory         = number<br>        cores          = number<br>        tags           = string<br>        ip             = optional(string, "dhcp")<br>        vmid           = optional(number, null)<br>        gw             = optional(string, null)<br>        vlan_tag       = optional(number, 3)<br>    }))</pre> | <pre>[<br>  {<br>    "cores": 2,<br>    "full_clone": true,<br>    "memory": 2048,<br>    "name": "vm",<br>    "network_bridge": "vmbr0",<br>    "storage": "Kingstone-data",<br>    "storage_size": 32,<br>    "tags": "tofu",<br>    "target_node": "proxmox",<br>    "template_name": "ubuntu-server-beta",<br>    "vlan_tag": 3<br>  }<br>]</pre> | no |
+| `vms` | List of VM definitions. `ip` defaults to `"dhcp"`. When `ip` is a static CIDR, `gw` **must** be provided — a missing gateway causes a plan-time validation error. | `list(object({...}))` | see variables.tf | no |
+| `environment` | Environment suffix appended to each VM name | `string` | `"dev"` | no |
+| `proxmox_host` | Proxmox API URL | `string` | `"https://192.168.0.131:8006/api2/json"` | no |
+| `proxmox_token_id` | Proxmox API token ID (`user@pam!token`) | `string` | `"terraform-prov@pve!terraform"` | no |
+| `proxmox_token_secret` | Proxmox API token secret | `string` | — | **yes** |
+
+### Per-VM object fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `string` | — | VM name (environment suffix added automatically) |
+| `target_node` | `string` | — | Proxmox node name |
+| `storage` | `string` | — | Storage pool name |
+| `storage_size` | `number` | — | Disk size in GB |
+| `full_clone` | `bool` | — | Full clone vs linked clone |
+| `template_name` | `string` | — | Template to clone from |
+| `network_bridge` | `string` | — | Network bridge (e.g. `vmbr0`) |
+| `memory` | `number` | — | RAM in MB |
+| `cores` | `number` | — | CPU core count |
+| `tags` | `string` | — | Proxmox tags |
+| `ip` | `string` | `"dhcp"` | CIDR address for static IP, or `"dhcp"` |
+| `gw` | `string` | `null` | Gateway — **required** when `ip` is not `"dhcp"` |
+| `vmid` | `number` | `null` | Proxmox VM ID (auto-assigned if null) |
+| `vlan_tag` | `number` | `3` | VLAN tag |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_vm_ips"></a> [vm\_ips](#output\_vm\_ips) | Map of VM key to default IPv4 address reported by the QEMU guest agent. |
-| <a name="output_vm_vmids"></a> [vm\_vmids](#output\_vm\_vmids) | Map of VM key to Proxmox VM ID. |
+| `vm_ips` | Map of VM name → IPv4 address (from QEMU guest agent) |
+| `vm_vmids` | Map of VM name → Proxmox VM ID |

--- a/example/dev.tfvars
+++ b/example/dev.tfvars
@@ -1,5 +1,6 @@
 vms = [
-    { 
+    # VM using DHCP — omit ip and gw (or set ip = "dhcp")
+    {
         name            = "vm-1"
         target_node     = "proxmox"
         storage         = "Kingstone-data"
@@ -11,10 +12,10 @@ vms = [
         cores           = 2
         tags            = "tofu"
         vlan_tag        = 3
-        # ip            = "192.168.3.10/24"  # optional: omit or set "dhcp" for DHCP
-        # gw            = "192.168.3.1"       # required when ip is static
+        # ip and gw omitted → defaults to DHCP
     },
-    { 
+    # VM using a static IP — both ip and gw are required
+    {
         name            = "vm-2"
         target_node     = "proxmox"
         storage         = "Kingstone-data"
@@ -26,6 +27,8 @@ vms = [
         cores           = 2
         tags            = "tofu"
         vlan_tag        = 3
+        ip              = "192.168.3.10/24"
+        gw              = "192.168.3.1"
     }
 ]
-environment       = "dev"
+environment = "dev"

--- a/local.tf
+++ b/local.tf
@@ -11,10 +11,10 @@ locals {
         memory          = vm.memory
         cores           = vm.cores
         tags            = vm.tags
-        ip              = lookup(vm, "ip", "dhcp")
-        vmid            = lookup(vm, "vmid", 200)
-        gw              = lookup(vm, "gw", "192.168.0.1")
-        vlan_tag        = lookup(vm, "vlan_tag", 3)
+        ip              = vm.ip
+        vmid            = vm.vmid
+        gw              = vm.gw
+        vlan_tag        = vm.vlan_tag
     }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,15 @@ variable "vms" {
         gw              = optional(string, null)
         vlan_tag        = optional(number, 3)
     }))
+
+    validation {
+        condition = alltrue([
+            for vm in var.vms :
+            vm.ip == "dhcp" || (vm.ip != "dhcp" && vm.gw != null)
+        ])
+        error_message = "Each VM with a static IP must also provide a 'gw' (gateway). Set ip = \"dhcp\" to use DHCP, or provide both 'ip' and 'gw' for a static configuration."
+    }
+
     default = [
         {
             name            = "vm"


### PR DESCRIPTION
## Summary

Closes #2

Fixes the silent hardcoded gateway fallback and makes DHCP vs static IP a clean, validated per-VM choice.

## Changes

### `local.tf`
Replaced all `lookup(vm, "field", hardcoded_default)` calls with direct `vm.field` access. The `optional()` defaults declared in `variables.tf` now apply correctly instead of being overridden.

| Before | After |
|--------|-------|
| `lookup(vm, "ip", "dhcp")` | `vm.ip` |
| `lookup(vm, "gw", "192.168.0.1")` | `vm.gw` |
| `lookup(vm, "vmid", 200)` | `vm.vmid` |

### `variables.tf`
Added a `validation` block to the `vms` variable:

```hcl
validation {
  condition = alltrue([
    for vm in var.vms :
    vm.ip == "dhcp" || (vm.ip != "dhcp" && vm.gw != null)
  ])
  error_message = "Each VM with a static IP must also provide a 'gw' (gateway)..."
}
```

`tofu plan` now fails fast with a descriptive error instead of applying a silently wrong gateway.

### `example/dev.tfvars`
Updated to show one DHCP VM and one static-IP VM side by side.

### `README.md`
Rewritten with usage examples for DHCP-only, static-IP, and mixed lists. Added per-VM field reference table.

## Test plan

- [ ] `tofu validate` passes ✅ (verified locally)
- [ ] `tofu plan` with DHCP-only `vms` → `ipconfig0 = "ip=dhcp"` for all VMs
- [ ] `tofu plan` with static IP + gw → `ipconfig0 = "ip=<cidr>,gw=<gw>"`
- [ ] `tofu plan` with static IP but **no** gw → plan fails with validation error
- [ ] `tofu plan` with mixed DHCP + static list → each VM resolves correctly
- [ ] `tofu apply` verified against a real Proxmox node

## Release

After merge: tag `0.0.2`, create GitHub Release `0.0.2-rc` (pre-release).

```bash
git tag 0.0.2 && git push origin 0.0.2
gh release create 0.0.2 --title "0.0.2-rc" --prerelease \
  --notes "RC for per-VM static IP / DHCP logic fix."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)