### PR TITLE
fix: add cloud-init drive (ide2) to VM disk config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,13 @@ resource "proxmox_vm_qemu" "vm" {
   clone = each.value.template_name
 
   disks {
+      ide {
+          ide2 {
+              cloudinit {
+                  storage = each.value.storage
+              }
+          }
+      }
       scsi {
           scsi0 {
               disk {


### PR DESCRIPTION
## Problem

Without an `ide2` cloud-init disk, the Proxmox provider sets `ipconfig0` on the VM
but the guest OS never receives it. `ds-identify` finds no datasource (no ISO 9660
cloud-init drive visible) and disables cloud-init entirely with:

```
cloud-init is enabled but no datasource found, disabling
```

This means all VMs provision with the template's default network config (DHCP) regardless
of the static IP set in `vms-config`.

## Fix

Add a `cloudinit` disk block at `ide2` inside the `disks` block. Proxmox will create a
cloud-init CD-ROM drive for each cloned VM, populated with the ipconfig0/user-data
from the Proxmox provider config. The guest's `ds-identify` can then find the NoCloud
datasource and apply the static IP.

## Test

Provision a VM with `"ip": "192.168.0.150/24", "gw": "192.168.0.1"` — after this fix
the VM boots with 192.168.0.150, not a DHCP address.