### PR TITLE
fix: separate cloud-init drive storage from VM disk storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "proxmox_vm_qemu" "vm" {
       ide {
           ide2 {
               cloudinit {
-                  storage = each.value.storage
+                  storage = each.value.cloudinit_storage
               }
           }
       }

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,20 @@
 variable "vms" {
     type = list(object({
-        name            = string
-        target_node     = string
-        storage         = string
-        storage_size    = number
-        full_clone      = bool
-        template_name   = string
-        network_bridge  = string
-        memory          = number
-        cores           = number
-        tags            = string
-        ip              = optional(string, "dhcp")
-        vmid            = optional(number, null)
-        gw              = optional(string, null)
-        vlan_tag        = optional(number, 3)
+        name               = string
+        target_node        = string
+        storage            = string
+        storage_size       = number
+        full_clone         = bool
+        template_name      = string
+        network_bridge     = string
+        memory             = number
+        cores              = number
+        tags               = string
+        ip                 = optional(string, "dhcp")
+        vmid               = optional(number, null)
+        gw                 = optional(string, null)
+        vlan_tag           = optional(number, 3)
+        cloudinit_storage  = optional(string, "local")
     }))
 
     validation {


### PR DESCRIPTION
## Problem

Proxmox cloud-init drives require a storage with **`images` content type**. Backup storages such as `Samsung_Backups` and `Kingstone_Backups` only support `backup` content — they cannot host cloud-init ISO files. When the `telmate/proxmox` provider attempts to create the cloud-init drive on an incompatible storage, Proxmox silently omits it.

**Symptom:** VMs boot without a cloud-init drive (`/dev/sr0` absent), so cloud-init finds no datasource, falls back to DHCP, and ignores the static `ipconfig0` setting. VMs end up at an unpredictable DHCP address instead of the configured static IP.

## Root Cause

`main.tf` used `each.value.storage` (the VM disk storage) for both the VM disk **and** the cloud-init drive:

```hcl
# Before — same storage for disk and cloud-init
ide2 {
    cloudinit {
        storage = each.value.storage  # "Samsung_Backups" — doesn't support images
    }
}
```

## Fix

Added a new `cloudinit_storage` field (default: `"local"`) to `variables.tf`, and updated `main.tf` to use it for the cloud-init drive only.

```hcl
# After — dedicated storage for cloud-init
ide2 {
    cloudinit {
        storage = each.value.cloudinit_storage  # "local" by default — supports images
    }
}
```

The `local` Proxmox storage supports the `images` content type and is available on all standard Proxmox installations. Callers can override `cloudinit_storage` per VM if their environment uses a different image-compatible storage.

## Changes

- `variables.tf` — added `cloudinit_storage = optional(string, "local")` to the `vms` variable type
- `main.tf` — `ide2.cloudinit.storage` now uses `each.value.cloudinit_storage` instead of `each.value.storage`

## Test Plan

- [ ] VM provisioned with static IP reaches SSH at the configured address (not a DHCP address)
- [ ] `/dev/sr0` (cloud-init CD-ROM) is visible in the provisioned VM via `lsblk`
- [ ] `cloud-init status` shows datasource `NoCloud` was used
- [ ] `ip addr` shows the static IP set in `ipconfig0`
- [ ] Existing callers that don't set `cloudinit_storage` get `local` by default (no breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)