### PR TITLE
fix: add cloudinit_storage to locals mapping

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -14,7 +14,8 @@ locals {
         ip              = vm.ip
         vmid            = vm.vmid
         gw              = vm.gw
-        vlan_tag        = vm.vlan_tag
+        vlan_tag           = vm.vlan_tag
+        cloudinit_storage  = vm.cloudinit_storage
     }
   ]
 }


### PR DESCRIPTION
local.tf was missing cloudinit_storage in the for-expression, causing:

```
Error: Unsupported attribute
  on main.tf line 37: storage = each.value.cloudinit_storage
This object does not have an attribute named "cloudinit_storage".
```

variables.tf and main.tf were updated in PR #5 but local.tf was missed.